### PR TITLE
Hotfix - Set role for application map

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "Shareable Logging Facade, implemented with Winston",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/applicationInsightsTransport.ts
+++ b/src/applicationInsightsTransport.ts
@@ -55,6 +55,13 @@ class ApplicationInsightsTransport extends Transport {
       .setSendLiveMetrics(false)
       .setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C)
       .start();
+    // The role we set determines what you see in the application map for
+    // the component using the logger
+    defaultClient.addTelemetryProcessor((envelope) => {
+      envelope.tags['ai.cloud.role'] = options.componentName;
+      return true;
+    });
+
     this.client = defaultClient;
   }
 

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -4,6 +4,7 @@ import { LOG_LEVELS } from '../enums';
 
 export interface ApplicationInsightsTransportOptions extends Transport.TransportStreamOptions {
   key: string;
+  componentName: string;
 }
 
 export type LogInfo = ExceptionInfo | EventInfo | TraceInfo;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -123,6 +123,7 @@ class Logger implements ILogger {
       transports.push(
         new ApplicationInsightsTransport({
           key: config.applicationInsights.key,
+          componentName: this.componentName,
           level: config.logs.level,
         }),
       );

--- a/tests/unit/applicationInsightsTransport.test.ts
+++ b/tests/unit/applicationInsightsTransport.test.ts
@@ -28,6 +28,7 @@ jest.mock('applicationinsights', () => ({
     trackTrace: jest.fn(),
     trackException: jest.fn(),
     trackEvent: jest.fn(),
+    addTelemetryProcessor: jest.fn(),
   },
   DistributedTracingModes: {
     AI_AND_W3C: 1,
@@ -39,8 +40,9 @@ describe('ApplicationInsightsTransport', () => {
     test('should create a new app insights client', () => {
       // Arrange
       const key = 'dummy-key';
+      const componentName = 'azure-logger';
       // Act
-      const result = new ApplicationInsightsTransport({ key });
+      const result = new ApplicationInsightsTransport({ key, componentName });
 
       // Assert
       expect(setup).toHaveBeenCalledWith(key);
@@ -49,6 +51,7 @@ describe('ApplicationInsightsTransport', () => {
   });
 
   describe('log', () => {
+    const key = 'dummy-key';
     const projectName = 'DVSA';
     const componentName = 'azure-logger';
     const message = 'mock-message';
@@ -57,7 +60,10 @@ describe('ApplicationInsightsTransport', () => {
     let applicationinsightsTransport: ApplicationInsightsTransport;
 
     beforeEach(() => {
-      applicationinsightsTransport = new ApplicationInsightsTransport({});
+      applicationinsightsTransport = new ApplicationInsightsTransport({
+        key,
+        componentName,
+      });
     });
 
     test('should create a trace log when provided with a audit log', () => {

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -47,6 +47,7 @@ describe('Logger', () => {
     expect(ApplicationInsightsTransport).toHaveBeenCalledWith({
       level: 'DEBUG',
       key: '123-456-789',
+      componentName: 'azure-logger',
     });
   });
 


### PR DESCRIPTION
On the application map in application insights all components using the node sdk are by default set to the role 'web' which messes up the map.

This PR fixes it so that we set the role to the component name so we can distinguish between different components. 