### PR TITLE
Hotifx - Set role for application map - option 2

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.0.1",
+  "version": "1.0.2",
   "description": "Shareable Logging Facade, implemented with Winston",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/applicationInsightsTransport.ts
+++ b/src/applicationInsightsTransport.ts
@@ -55,14 +55,9 @@ class ApplicationInsightsTransport extends Transport {
       .setSendLiveMetrics(false)
       .setDistributedTracingMode(DistributedTracingModes.AI_AND_W3C)
       .start();
-    // The role we set determines what you see in the application map for
-    // the component using the logger
-    defaultClient.addTelemetryProcessor((envelope) => {
-      envelope.tags['ai.cloud.role'] = options.componentName;
-      return true;
-    });
 
     this.client = defaultClient;
+    this.client.context.tags[this.client.context.keys.cloudRole] = options.componentName;
   }
 
   log(info: LogInfo, callback: Function): void {

--- a/tests/unit/applicationInsightsTransport.test.ts
+++ b/tests/unit/applicationInsightsTransport.test.ts
@@ -24,16 +24,23 @@ jest.mock('applicationinsights', () => ({
     setDistributedTracingMode: jest.fn().mockReturnThis(),
   }),
   defaultClient: {
-    context: 'Created by Mock',
+    context: {
+      keys: {
+        cloudRole: 'cloudRole',
+      },
+      tags: {
+        cloudRole: '',
+      },
+    },
     trackTrace: jest.fn(),
     trackException: jest.fn(),
     trackEvent: jest.fn(),
-    addTelemetryProcessor: jest.fn(),
   },
   DistributedTracingModes: {
     AI_AND_W3C: 1,
   },
 }));
+
 
 describe('ApplicationInsightsTransport', () => {
   describe('constructor', () => {
@@ -46,7 +53,7 @@ describe('ApplicationInsightsTransport', () => {
 
       // Assert
       expect(setup).toHaveBeenCalledWith(key);
-      expect(result.client.context).toEqual('Created by Mock');
+      expect(result.client.context.tags.cloudRole).toEqual(componentName);
     });
   });
 


### PR DESCRIPTION
On the application map in application insights all components using the node sdk are by default set to the role 'web' which messes up the map.

As the first attempt didn't work, this PR implements the second way of doing it in the docs so that we set the role to the component name so we can distinguish between different components.