### PR TITLE
FTT-2602 - Managing operation ids

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,42 +1,83 @@
-# Logger
-Dvsa FTTS uses Winston as the logging facade.
+# Azure Logger
 
-## Usage
-Firstly, install the library
+Winston Logger with a custom Azure Application Insights Transport
+
+### Logging levels
+* critical
+* error
+* warn
+* info
+* debug
+* security
+* audit
+* log
+* event
+
+## Installation
+
+If using npm:
 ```
 npm install @dvsa/azure-logger
 ```
-
 or if using Yarn
-
 ```
 yarn add @dvsa/azure-logger
 ```
 
-Specify the environment variables in an .env file, for example
-
+Specify the environment variables in a .env file, for example
 ```
 LOG_LEVEL=debug
+
 NODE_ENV=development
+
 APPINSIGHTS_INSTRUMENTATIONKEY={APP_INSIGHTS_KEY}
 ```
+## How to use:
 
-How to use:
+1) Create a class which extends the Azure Logger called logger.ts
 ```typescript
-import { Logger } from '@dvsa/azure-logger';
-// create the logger
-const logger = new Logger("project-name", "component-name")
-// do some logging!
-logger.log('Hello World');
-logger.error('Error %o', err);
+import { Context } from  '@azure/functions';
+import { Logger  as  AzureLogger } from  '@dvsa/azure-logger';
+
+class Logger extends AzureLogger {
+    constructor() {
+        super('project-name', 'component-name');
+    }
+
+    setup(context: Context): void {
+        super.setup(context);
+    }
+}
+
+export default new Logger();
 ```
 
-### Logging levels
- * critical
- * error
- * warn
- * info
- * debug
- * security
- * audit
- * log
+2.  At the start of the azure function call setup and pass the function context in
+```typescript
+import Logger from './logger';
+
+const  httpTrigger: AzureFunction = async (context: Context): Promise<void> => {
+    Logger.setup(context);
+    // Rest of Function
+};
+
+export  default  httpTrigger;
+```
+3. Whenever you want to log an item use the logger.
+```typescript
+import Logger from './logger';
+
+function getData(): void {
+    try {
+        // Do calculations
+    } catch(error) {
+        Logger.error(error);
+    }
+}
+```
+
+## APPINSIGHTS_INSTRUMENTATIONKEY
+
+ When using an Azure app function the following environment variable must be present and contain the key for the application insights instance you wish to use.
+  
+  APPINSIGHTS_INSTRUMENTATIONKEY

--- a/package-lock.json
+++ b/package-lock.json
@@ -4,6 +4,12 @@
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {
+    "@azure/functions": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@azure/functions/-/functions-1.2.0.tgz",
+      "integrity": "sha512-qkaQqTnr56xUnYNkKBM/2wsnf6imAJ3NF6Nbpk691Y6JYliA1YdZngsZsrpHS9tQ9/71MqARl8m50+EmEfLG3g==",
+      "dev": true
+    },
     "@babel/code-frame": {
       "version": "7.8.3",
       "resolved": "https://registry.npmjs.org/@babel/code-frame/-/code-frame-7.8.3.tgz",
@@ -1610,6 +1616,12 @@
       "integrity": "sha512-l42BggppR6zLmpfU6fq9HEa2oGPEI8yrSPL3GITjfRInppYFahObbIQOQK3UGxEnyQpltZLaPe75046NOZQikw==",
       "dev": true
     },
+    "@types/uuid": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/@types/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-xSQfNcvOiE5f9dyd4Kzxbof1aTrLobL278pGLKOZI6esGfZ7ts9Ka16CzIN6Y8hFHE1C7jIBZokULhK1bOgjRw==",
+      "dev": true
+    },
     "@types/yargs": {
       "version": "15.0.3",
       "resolved": "https://registry.npmjs.org/@types/yargs/-/yargs-15.0.3.tgz",
@@ -1773,14 +1785,14 @@
       }
     },
     "applicationinsights": {
-      "version": "1.7.4",
-      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.4.tgz",
-      "integrity": "sha512-XFLsNlcanpjFhHNvVWEfcm6hr7lu9znnb6Le1Lk5RE03YUV9X2B2n2MfM4kJZRrUdV+C0hdHxvWyv+vWoLfY7A==",
+      "version": "1.7.5",
+      "resolved": "https://registry.npmjs.org/applicationinsights/-/applicationinsights-1.7.5.tgz",
+      "integrity": "sha512-sl3rNhVnQOG4ecJNKh7dlAZOc/DLfZTRs1F6PO3nb969AsnVg7C4xWRoybI9+mbtqyPR4NA2JbG4bHJOGP3j+A==",
       "requires": {
         "cls-hooked": "^4.2.2",
         "continuation-local-storage": "^3.2.1",
         "diagnostic-channel": "0.2.0",
-        "diagnostic-channel-publishers": "^0.3.3"
+        "diagnostic-channel-publishers": "^0.3.4"
       }
     },
     "argparse": {
@@ -2657,9 +2669,9 @@
       }
     },
     "diagnostic-channel-publishers": {
-      "version": "0.3.3",
-      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.3.tgz",
-      "integrity": "sha512-qIocRYU5TrGUkBlDDxaziAK1+squ8Yf2Ls4HldL3xxb/jzmWO2Enux7CvevNKYmF2kDXZ9HiRqwjPsjk8L+i2Q=="
+      "version": "0.3.4",
+      "resolved": "https://registry.npmjs.org/diagnostic-channel-publishers/-/diagnostic-channel-publishers-0.3.4.tgz",
+      "integrity": "sha512-SZ1zMfFiEabf4Qx0Og9V1gMsRoqz3O+5ENkVcNOfI+SMJ3QhQsdEoKX99r0zvreagXot2parPxmrwwUM/ja8ug=="
     },
     "diagnostics": {
       "version": "1.1.1",
@@ -6592,6 +6604,12 @@
             "psl": "^1.1.28",
             "punycode": "^2.1.1"
           }
+        },
+        "uuid": {
+          "version": "3.4.0",
+          "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
+          "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
+          "dev": true
         }
       }
     },
@@ -7794,10 +7812,9 @@
       }
     },
     "uuid": {
-      "version": "3.4.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-3.4.0.tgz",
-      "integrity": "sha512-HjSDRw6gZE5JMggctHBcjVak08+KEVhSIiDzFnT9S9aegmp85S/bReBVTb4QTFaRNptJ9kuYaNhnbNEOkbKb/A==",
-      "dev": true
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
+      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
     },
     "v8-compile-cache": {
       "version": "2.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -15,12 +15,14 @@
   "license": "MIT",
   "repository": "github:dvsa/azure-logger",
   "devDependencies": {
+    "@azure/functions": "^1.2.0",
     "@babel/core": "^7.8.4",
     "@babel/preset-env": "^7.8.4",
     "@babel/preset-typescript": "^7.8.3",
     "@dvsa/eslint-config-ts": "^1.0.0",
     "@types/jest": "^25.1.2",
     "@types/node": "^13.7.1",
+    "@types/uuid": "^8.0.0",
     "babel-jest": "^25.1.0",
     "eslint": "^6.8.0",
     "jest": "^25.1.0",
@@ -28,8 +30,9 @@
     "typescript": "^3.7.5"
   },
   "dependencies": {
-    "applicationinsights": "^1.7.4",
+    "applicationinsights": "^1.7.5",
     "dotenv": "^8.2.0",
+    "uuid": "^8.0.0",
     "winston": "3.1.0",
     "winston-transport": "^4.3.0"
   },

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.0.3",
+  "version": "1.1.0",
   "description": "Shareable Logging Facade, implemented with Winston",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/applicationInsightsTransport.ts
+++ b/src/applicationInsightsTransport.ts
@@ -58,6 +58,8 @@ class ApplicationInsightsTransport extends Transport {
 
     this.client = defaultClient;
     this.client.context.tags[this.client.context.keys.cloudRole] = options.componentName;
+    this.client.context.tags[this.client.context.keys.operationId] = options.operationId;
+    this.client.context.tags[this.client.context.keys.operationParentId] = options.parentOperationId;
   }
 
   log(info: LogInfo, callback: Function): void {

--- a/src/applicationInsightsTransport.ts
+++ b/src/applicationInsightsTransport.ts
@@ -58,6 +58,11 @@ class ApplicationInsightsTransport extends Transport {
 
     this.client = defaultClient;
     this.client.context.tags[this.client.context.keys.cloudRole] = options.componentName;
+    /* Code below has been added as a workaround for the following issue:
+        https://github.com/microsoft/ApplicationInsights-node.js/issues/585
+      Once issue has been fixed the logger and it's implmentation can be simplified so it
+      is closer to v1.0.0
+    */
     this.client.context.tags[this.client.context.keys.operationId] = options.operationId;
     this.client.context.tags[this.client.context.keys.operationParentId] = options.parentOperationId;
   }

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,6 +5,8 @@ import { LOG_LEVELS } from '../enums';
 export interface ApplicationInsightsTransportOptions extends Transport.TransportStreamOptions {
   key: string;
   componentName: string;
+  parentOperationId: string;
+  operationId: string;
 }
 
 export type LogInfo = ExceptionInfo | EventInfo | TraceInfo;

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -151,7 +151,7 @@ class Logger implements ILogger {
 
   private getLoggerInstance(): WinstonLogger {
     if (!this.loggerInstance) {
-      throw new Error('Logger is not configured, please run setupLogger() first');
+      throw new Error('Logger is not configured, please run Logger.setup() first');
     }
     return this.loggerInstance;
   }

--- a/src/logger.ts
+++ b/src/logger.ts
@@ -1,15 +1,30 @@
 import winston, { Logger as WinstonLogger } from 'winston';
 import Transport from 'winston-transport';
+// eslint-disable-next-line import/no-unresolved
+import { Context } from '@azure/functions';
+import { v4 as uuidv4 } from 'uuid';
 import config from './config';
 import ILogger from './ILogger';
 import ApplicationInsightsTransport from './applicationInsightsTransport';
 import { LOG_LEVELS } from './enums';
 
 class Logger implements ILogger {
-  private loggerInstance: WinstonLogger;
+  private loggerInstance: WinstonLogger| undefined;
 
-  constructor(private projectName: string, private componentName: string) {
-    const transports = this.getWinstonTransports();
+  constructor(private projectName: string, private componentName: string) {}
+
+  setup(context: Context): void {
+    const operationId: string = uuidv4();
+    let parentOperationId: string;
+
+    if (context.traceContext && context.traceContext.traceparent) {
+      const { traceparent } = context.traceContext;
+      parentOperationId = traceparent ? traceparent.split('-')[1] : operationId;
+    } else {
+      parentOperationId = operationId;
+    }
+
+    const transports = this.getWinstonTransports(parentOperationId, operationId);
     const customLevels = {
       [LOG_LEVELS.CRITICAL]: 0,
       [LOG_LEVELS.ERROR]: 1,
@@ -33,7 +48,7 @@ class Logger implements ILogger {
   }
 
   critical(message: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.log(LOG_LEVELS.CRITICAL, message, {
+    this.getLoggerInstance().log(LOG_LEVELS.CRITICAL, message, {
       projectName: this.projectName,
       componentName: this.componentName,
       ...properties,
@@ -41,7 +56,7 @@ class Logger implements ILogger {
   }
 
   debug(message: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.log(LOG_LEVELS.DEBUG, message, {
+    this.getLoggerInstance().log(LOG_LEVELS.DEBUG, message, {
       projectName: this.projectName,
       componentName: this.componentName,
       ...properties,
@@ -49,7 +64,7 @@ class Logger implements ILogger {
   }
 
   audit(message: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.log(LOG_LEVELS.AUDIT, message, {
+    this.getLoggerInstance().log(LOG_LEVELS.AUDIT, message, {
       projectName: this.projectName,
       componentName: this.componentName,
       ...properties,
@@ -57,7 +72,7 @@ class Logger implements ILogger {
   }
 
   security(message: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.log(LOG_LEVELS.SECURITY, message, {
+    this.getLoggerInstance().log(LOG_LEVELS.SECURITY, message, {
       projectName: this.projectName,
       componentName: this.componentName,
       ...properties,
@@ -65,7 +80,7 @@ class Logger implements ILogger {
   }
 
   error(error: Error, message?: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.error(message || '', {
+    this.getLoggerInstance().error(message || '', {
       error,
       projectName: this.projectName,
       componentName: this.componentName,
@@ -74,7 +89,7 @@ class Logger implements ILogger {
   }
 
   info(message: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.info(message, {
+    this.getLoggerInstance().info(message, {
       projectName: this.projectName,
       componentName: this.componentName,
       ...properties,
@@ -82,7 +97,7 @@ class Logger implements ILogger {
   }
 
   log(message: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.log(LOG_LEVELS.INFO, message, {
+    this.getLoggerInstance().log(LOG_LEVELS.INFO, message, {
       projectName: this.projectName,
       componentName: this.componentName,
       ...properties,
@@ -90,7 +105,7 @@ class Logger implements ILogger {
   }
 
   warn(message: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.log(LOG_LEVELS.WARNING, message, {
+    this.getLoggerInstance().log(LOG_LEVELS.WARNING, message, {
       projectName: this.projectName,
       componentName: this.componentName,
       ...properties,
@@ -98,7 +113,7 @@ class Logger implements ILogger {
   }
 
   event(name: string, message?: string, properties?: {[key: string]: string}): void {
-    this.loggerInstance.log(LOG_LEVELS.EVENT, message || '', {
+    this.getLoggerInstance().log(LOG_LEVELS.EVENT, message || '', {
       name,
       projectName: this.projectName,
       componentName: this.componentName,
@@ -106,7 +121,7 @@ class Logger implements ILogger {
     });
   }
 
-  private getWinstonTransports(): Transport[] {
+  private getWinstonTransports(parentOperationId: string, operationId: string): Transport[] {
     const transports: Transport[] = [];
 
     if (config.developmentMode) {
@@ -125,11 +140,20 @@ class Logger implements ILogger {
           key: config.applicationInsights.key,
           componentName: this.componentName,
           level: config.logs.level,
+          operationId,
+          parentOperationId,
         }),
       );
     }
 
     return transports;
+  }
+
+  private getLoggerInstance(): WinstonLogger {
+    if (!this.loggerInstance) {
+      throw new Error('Logger is not configured, please run setupLogger() first');
+    }
+    return this.loggerInstance;
   }
 }
 

--- a/tests/unit/applicationInsightsTransport.test.ts
+++ b/tests/unit/applicationInsightsTransport.test.ts
@@ -27,9 +27,13 @@ jest.mock('applicationinsights', () => ({
     context: {
       keys: {
         cloudRole: 'cloudRole',
+        operationId: 'operationId',
+        operationParentId: 'operationParentId',
       },
       tags: {
         cloudRole: '',
+        operationId: '',
+        operationParentId: '',
       },
     },
     trackTrace: jest.fn(),
@@ -48,12 +52,18 @@ describe('ApplicationInsightsTransport', () => {
       // Arrange
       const key = 'dummy-key';
       const componentName = 'azure-logger';
+      const parentOperationId = 'parent-operation-id';
+      const operationId = 'operation-id';
       // Act
-      const result = new ApplicationInsightsTransport({ key, componentName });
+      const result = new ApplicationInsightsTransport({
+        key, componentName, parentOperationId, operationId,
+      });
 
       // Assert
       expect(setup).toHaveBeenCalledWith(key);
       expect(result.client.context.tags.cloudRole).toEqual(componentName);
+      expect(result.client.context.tags.operationParentId).toEqual(parentOperationId);
+      expect(result.client.context.tags.operationId).toEqual(operationId);
     });
   });
 
@@ -63,6 +73,8 @@ describe('ApplicationInsightsTransport', () => {
     const componentName = 'azure-logger';
     const message = 'mock-message';
     const eventName = 'mock-event-name';
+    const parentOperationId = 'parent-operation-id';
+    const operationId = 'operation-id';
 
     let applicationinsightsTransport: ApplicationInsightsTransport;
 
@@ -70,6 +82,8 @@ describe('ApplicationInsightsTransport', () => {
       applicationinsightsTransport = new ApplicationInsightsTransport({
         key,
         componentName,
+        parentOperationId,
+        operationId,
       });
     });
 

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -36,7 +36,7 @@ describe('Logger', () => {
   };
   const logMessage = 'test log message';
   const logProps = { componentName: 'azure-logger', projectName: 'DVSA' };
-  const notSetupErrorMessage = 'Logger is not configured, please run setupLogger() first';
+  const notSetupErrorMessage = 'Logger is not configured, please run Logger.setup() first';
 
   beforeAll(() => {
     mockCreateLogger = jest.spyOn(winston, 'createLogger');

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -13,6 +13,9 @@ jest.mock('../../src/config', () => ({
     key: '123-456-789',
   },
 }));
+jest.mock('uuid', () => ({
+  v4: jest.fn().mockReturnValue('mock-uuid'),
+}));
 
 describe('Logger', () => {
   let loggerInstance: Logger;
@@ -24,10 +27,23 @@ describe('Logger', () => {
     log: jest.fn(),
     warn: jest.fn(),
   };
+  const mockContext: any = {
+    traceContext: {
+      traceparent: 'trace-parent',
+      tracestate: 'trace-state',
+      attributes: {},
+    },
+  };
+  const logMessage = 'test log message';
+  const logProps = { componentName: 'azure-logger', projectName: 'DVSA' };
+  const notSetupErrorMessage = 'Logger is not configured, please run setupLogger() first';
 
   beforeAll(() => {
     mockCreateLogger = jest.spyOn(winston, 'createLogger');
     mockCreateLogger.mockImplementation(() => mockLogger);
+  });
+
+  beforeEach(() => {
     loggerInstance = new Logger('DVSA', 'azure-logger');
   });
 
@@ -39,158 +55,394 @@ describe('Logger', () => {
     jest.restoreAllMocks();
   });
 
-  test('configures application insights', () => {
-    // act
-    loggerInstance.log('Test Log');
-
-    // assert
-    expect(ApplicationInsightsTransport).toHaveBeenCalledWith({
-      level: 'DEBUG',
-      key: '123-456-789',
-      componentName: 'azure-logger',
+  describe('setup', () => {
+    test('should correctly configure application insights', () => {
+      // act
+      loggerInstance.setup(mockContext);
+      // assert
+      expect(ApplicationInsightsTransport).toHaveBeenCalledWith({
+        level: 'DEBUG',
+        key: '123-456-789',
+        componentName: 'azure-logger',
+        operationId: 'mock-uuid',
+        parentOperationId: 'parent',
+      });
     });
   });
 
-  test('critical logs', () => {
-    // arrange
-    const message = 'Critical log';
+  describe('critical', () => {
+    test('should create a critical log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.critical(logMessage);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.CRITICAL,
+        logMessage,
+        logProps,
+      );
+    });
 
-    // act
-    loggerInstance.critical(message);
+    test('should create a critical log with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.critical(logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.CRITICAL,
+        logMessage,
+        {...logProps, isTest: 'true'},
+      );
+    });
 
-    // assert
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      LOG_LEVELS.CRITICAL,
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA' },
-    );
-  });
-
-  test('debug logs', () => {
-    // arrange
-    const message = 'Debug log';
-
-    // act
-    loggerInstance.debug(message);
-
-    // assert
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      LOG_LEVELS.DEBUG,
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA' },
-    );
-  });
-
-  test('audit logs', () => {
-    // arrange
-    const message = 'Audit log';
-
-    // act
-    loggerInstance.audit(message);
-
-    // assert
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      LOG_LEVELS.AUDIT,
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA' },
-    );
-  });
-
-  test('security logs', () => {
-    // arrange
-    const message = 'Audit log';
-
-    // act
-    loggerInstance.security(message);
-
-    // assert
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      LOG_LEVELS.SECURITY,
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA' },
-    );
-  });
-
-  test('error logs', () => {
-    // arrange
-    const message = 'Error log';
-    const error: Error = new Error('Test Error');
-    // act
-    loggerInstance.error(error, message);
-
-    // assert
-    expect(mockLogger.error).toHaveBeenCalledWith(
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA', error },
-    );
-  });
-
-  test('info logs', () => {
-    // arrange
-    const message = 'Info log';
-
-    // act
-    loggerInstance.info(message);
-
-    // assert
-    expect(mockLogger.info).toHaveBeenCalledWith(
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA' },
-    );
-  });
-
-  test('log logs', () => {
-    // arrange
-    const message = 'Log log';
-
-    // act
-    loggerInstance.log(message);
-
-    // assert
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      LOG_LEVELS.INFO,
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA' },
-    );
-  });
-
-  test('warn logs', () => {
-    // arrange
-    const message = 'Warn log';
-
-    // act
-    loggerInstance.warn(message);
-
-    // assert
-    expect(mockLogger.log).toHaveBeenCalledWith(
-      LOG_LEVELS.WARNING,
-      message,
-      { componentName: 'azure-logger', projectName: 'DVSA' },
-    );
-  });
-
-  test('event logs call the logger with the correct data when no optional data is provided', () => {
-    // Act
-    loggerInstance.event('mock-name');
-
-    // Assert
-    expect(mockLogger.log).toHaveBeenCalledWith(LOG_LEVELS.EVENT, '', {
-      componentName: 'azure-logger',
-      projectName: 'DVSA',
-      name: 'mock-name',
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.critical(logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
     });
   });
 
-  test('event logs call the logger with the correct data when all optional data is provided', () => {
-    // Act
-    loggerInstance.event('mock-name', 'mock-message', { mockData: 'mock-data' });
+  describe('debug', () => {
+    test('should create a debug log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.debug(logMessage);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.DEBUG,
+        logMessage,
+        logProps,
+      );
+    });
 
-    // Assert
-    expect(mockLogger.log).toHaveBeenCalledWith(LOG_LEVELS.EVENT, 'mock-message', {
-      componentName: 'azure-logger',
-      projectName: 'DVSA',
-      mockData: 'mock-data',
-      name: 'mock-name',
+    test('should create a debug log with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.debug(logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.DEBUG,
+        logMessage,
+        { ...logProps, isTest: 'true' },
+      );
+    });
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.debug(logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
+    });
+  });
+
+  describe('audit', () => {
+    test('should create a audit log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.audit(logMessage);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.AUDIT,
+        logMessage,
+        logProps,
+      );
+    });
+
+    test('should create a audit log with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.audit(logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.AUDIT,
+        logMessage,
+        { ...logProps, isTest: 'true' },
+      );
+    });
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.audit(logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
+    });
+  });
+
+  describe('security', () => {
+    test('should create a security log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.security(logMessage);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.SECURITY,
+        logMessage,
+        logProps,
+      );
+    });
+
+    test('should create a security log with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.security(logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.SECURITY,
+        logMessage,
+        { ...logProps, isTest: 'true' },
+      );
+    });
+
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.security(logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
+    });
+  });
+
+  describe('error', () => {
+    const mockError = new Error('Mock Error');
+
+    test('should create a error log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.error(mockError);
+      // assert
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '',
+        { ...logProps, error: mockError },
+      );
+    });
+
+    test('should create a error log with an optional error message', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.error(mockError, logMessage);
+      // assert
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        logMessage,
+        { ...logProps, error: mockError },
+      );
+    });
+
+    test('should create a error log with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.error(mockError, undefined, { isTest: 'true' });
+      // assert
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        '',
+        { ...logProps, error: mockError, isTest: 'true' },
+      );
+    });
+
+    test('should create a error log with an optional message and properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.error(mockError, logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.error).toHaveBeenCalledWith(
+        logMessage,
+        { ...logProps, error: mockError, isTest: 'true' },
+      );
+    });
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.error(mockError, logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
+    });
+  });
+
+  describe('info', () => {
+    test('should create a info log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.info(logMessage);
+      // assert
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        logMessage,
+        logProps,
+      );
+    });
+
+    test('should create a info log with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.info(logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.info).toHaveBeenCalledWith(
+        logMessage,
+        { ...logProps, isTest: 'true' },
+      );
+    });
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.info(logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
+    });
+  });
+
+  describe('log', () => {
+    test('should create a log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.log(logMessage);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.INFO,
+        logMessage,
+        logProps,
+      );
+    });
+
+    test('should create a log with additional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.log(logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.INFO,
+        logMessage,
+        { ...logProps, isTest: 'true' },
+      );
+    });
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.log(logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
+    });
+  });
+
+  describe('warn', () => {
+    test('should create a warn log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.warn(logMessage);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.WARNING,
+        logMessage,
+        logProps,
+      );
+    });
+
+    test('should create a warn log with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.warn(logMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.WARNING,
+        logMessage,
+        { ...logProps, isTest: 'true' },
+      );
+    });
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.warn(logMessage);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
+    });
+  });
+
+  describe('event', () => {
+    const mockEventName = 'mock-event';
+    const mockEventMessage = 'mock-event-message';
+
+    test('should create a event log', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.event(mockEventName);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.EVENT,
+        '',
+        { ...logProps, name: mockEventName },
+      );
+    });
+
+    test('should create a event with an optional message', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.event(mockEventName, mockEventMessage);
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.EVENT,
+        mockEventMessage,
+        { ...logProps, name: mockEventName },
+      );
+    });
+
+    test('should create a event with optional properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.event(mockEventName, undefined, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.EVENT,
+        '',
+        { ...logProps, name: mockEventName, isTest: 'true' },
+      );
+    });
+
+    test('should create a event with an optional message and properties', () => {
+      // arrange
+      loggerInstance.setup(mockContext);
+      // act
+      loggerInstance.event(mockEventName, mockEventMessage, { isTest: 'true' });
+      // assert
+      expect(mockLogger.log).toHaveBeenCalledWith(
+        LOG_LEVELS.EVENT,
+        mockEventMessage,
+        { ...logProps, name: mockEventName, isTest: 'true' },
+      );
+    });
+
+    test('should throw an error if setup has not been run', () => {
+      try {
+        loggerInstance.event(mockEventName);
+      } catch (error) {
+        expect(error.message).toEqual(notSetupErrorMessage);
+      }
     });
   });
 });


### PR DESCRIPTION
The update:

- Upgrades us to using the latest application insights package
- Introduces a workaround where we have to manually set the operation id and parent operation id
- A setup function must now be run to setup the workaround and logger. If it's not called , the log method will throw an exception
- Readme updated with code examples on how to use the logger (Thanks Prem for the idea)