### PR TITLE
FTT-2602 - Stop setting Parent ID

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -7811,11 +7811,6 @@
         "object.getownpropertydescriptors": "^2.1.0"
       }
     },
-    "uuid": {
-      "version": "8.0.0",
-      "resolved": "https://registry.npmjs.org/uuid/-/uuid-8.0.0.tgz",
-      "integrity": "sha512-jOXGuXZAWdsTH7eZLtyXMqUb9EcWMGZNbL9YcGBJl4MH4nrxHmZJhEHvyLFrkxo+28uLb/NYRcStH48fnD0Vzw=="
-    },
     "v8-compile-cache": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/v8-compile-cache/-/v8-compile-cache-2.1.0.tgz",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.1.0",
+  "version": "1.1.1",
   "description": "Shareable Logging Facade, implemented with Winston",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -32,7 +32,6 @@
   "dependencies": {
     "applicationinsights": "^1.7.5",
     "dotenv": "^8.2.0",
-    "uuid": "^8.0.0",
     "winston": "3.1.0",
     "winston-transport": "^4.3.0"
   },

--- a/src/applicationInsightsTransport.ts
+++ b/src/applicationInsightsTransport.ts
@@ -64,7 +64,6 @@ class ApplicationInsightsTransport extends Transport {
       is closer to v1.0.0
     */
     this.client.context.tags[this.client.context.keys.operationId] = options.operationId;
-    this.client.context.tags[this.client.context.keys.operationParentId] = options.parentOperationId;
   }
 
   log(info: LogInfo, callback: Function): void {

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,7 +5,6 @@ import { LOG_LEVELS } from '../enums';
 export interface ApplicationInsightsTransportOptions extends Transport.TransportStreamOptions {
   key: string;
   componentName: string;
-  parentOperationId: string;
   operationId: string;
 }
 

--- a/tests/unit/applicationInsightsTransport.test.ts
+++ b/tests/unit/applicationInsightsTransport.test.ts
@@ -52,17 +52,15 @@ describe('ApplicationInsightsTransport', () => {
       // Arrange
       const key = 'dummy-key';
       const componentName = 'azure-logger';
-      const parentOperationId = 'parent-operation-id';
       const operationId = 'operation-id';
       // Act
       const result = new ApplicationInsightsTransport({
-        key, componentName, parentOperationId, operationId,
+        key, componentName, operationId,
       });
 
       // Assert
       expect(setup).toHaveBeenCalledWith(key);
       expect(result.client.context.tags.cloudRole).toEqual(componentName);
-      expect(result.client.context.tags.operationParentId).toEqual(parentOperationId);
       expect(result.client.context.tags.operationId).toEqual(operationId);
     });
   });
@@ -73,7 +71,6 @@ describe('ApplicationInsightsTransport', () => {
     const componentName = 'azure-logger';
     const message = 'mock-message';
     const eventName = 'mock-event-name';
-    const parentOperationId = 'parent-operation-id';
     const operationId = 'operation-id';
 
     let applicationinsightsTransport: ApplicationInsightsTransport;
@@ -82,7 +79,6 @@ describe('ApplicationInsightsTransport', () => {
       applicationinsightsTransport = new ApplicationInsightsTransport({
         key,
         componentName,
-        parentOperationId,
         operationId,
       });
     });

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -13,9 +13,6 @@ jest.mock('../../src/config', () => ({
     key: '123-456-789',
   },
 }));
-jest.mock('uuid', () => ({
-  v4: jest.fn().mockReturnValue('mock-uuid'),
-}));
 
 describe('Logger', () => {
   let loggerInstance: Logger;
@@ -64,8 +61,7 @@ describe('Logger', () => {
         level: 'DEBUG',
         key: '123-456-789',
         componentName: 'azure-logger',
-        operationId: 'mock-uuid',
-        parentOperationId: 'parent',
+        operationId: 'parent',
       });
     });
   });


### PR DESCRIPTION
In the current implementation, we have broken the link between components, 

I believe is down to us always overwriting the parent trace id, when testing if no parent trace id is set it will automatically use the trace id for both fields, so we shouldn't need to set the parent one manually.

