### PR TITLE
FTT-2602 - Final version and tidy up

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,38 +26,107 @@ yarn add @dvsa/azure-logger
 
 Specify the environment variables in a .env file, for example
 ```
-LOG_LEVEL=debug
+LOG_LEVEL=event
 
 NODE_ENV=development
 
 APPINSIGHTS_INSTRUMENTATIONKEY={APP_INSIGHTS_KEY}
 ```
-## How to use:
+## Example Use:
 
-1) Create a class which extends the Azure Logger called logger.ts
+1) Create a class Logger called logger.ts. In this class we will create an instance of the Azure Logger, work out the operation id, and provide a wrapper for all the logger functions so we don't need to worry about the operation id elsewhere in the code.
 ```typescript
-import { Context } from  '@azure/functions';
-import { Logger  as  AzureLogger } from  '@dvsa/azure-logger';
+import { Context } from '@azure/functions';
+import { Logger as AzureLogger, getOperationId } from '@dvsa/azure-logger';
 
-class Logger extends AzureLogger {
-    constructor() {
-        super('project-name', 'component-name');
-    }
 
-    setup(context: Context): void {
-        super.setup(context);
+class Logger {
+  private azureLogger: AzureLogger;
+  private operationId: string | undefined;
+  private noOperationIdErrorMessage = 'configureOperationId must be run before using the logger';
+
+  constructor() {
+    this.azureLogger = new AzureLogger('ftts', 'ftts-location-api');
+  }
+
+  configureOperationId(context: Context): void {
+    this.operationId = getOperationId(context);
+  }
+
+  critical(message: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
     }
+    this.azureLogger.critical(message, this.operationId, properties);
+  }
+
+  error(error: Error, message?: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.error(error, this.operationId, message, properties);
+  }
+
+  warn(message: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.warn(message, this.operationId, properties);
+  }
+
+  info(message: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.info(message, this.operationId, properties);
+  }
+
+  debug(message: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.debug(message, this.operationId, properties);
+  }
+
+  log(message: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.log(message, this.operationId, properties);
+  }
+
+  audit(message: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.audit(message, this.operationId, properties);
+  }
+
+  security(message: string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.security(message, this.operationId, properties);
+  }
+
+  event(name: string, message? : string, properties?: {[key: string]: string}): void {
+    if (!this.operationId) {
+      throw new Error(this.noOperationIdErrorMessage);
+    }
+    this.azureLogger.event(name, this.operationId, message, properties);
+  }
 }
 
 export default new Logger();
+
 ```
 
-2.  At the start of the azure function call setup and pass the function context in
+2.  At the start of the azure function call configureOperationId and pass the function context in
 ```typescript
-import Logger from './logger';
+import logger from './logger';
 
 const  httpTrigger: AzureFunction = async (context: Context): Promise<void> => {
-    Logger.setup(context);
+    logger.configureOperationId(context);
     // Rest of Function
 };
 
@@ -65,13 +134,13 @@ export  default  httpTrigger;
 ```
 3. Whenever you want to log an item use the logger.
 ```typescript
-import Logger from './logger';
+import logger from './logger';
 
 function getData(): void {
     try {
         // Do calculations
     } catch(error) {
-        Logger.error(error);
+        logger.error(error);
     }
 }
 ```

--- a/README.md
+++ b/README.md
@@ -36,14 +36,16 @@ APPINSIGHTS_INSTRUMENTATIONKEY={APP_INSIGHTS_KEY}
 
 1) Create a class Logger called logger.ts. In this class we will create an instance of the Azure Logger, work out the operation id, and provide a wrapper for all the logger functions so we don't need to worry about the operation id elsewhere in the code.
 ```typescript
+// eslint-disable-next-line import/no-unresolved
 import { Context } from '@azure/functions';
 import { Logger as AzureLogger, getOperationId } from '@dvsa/azure-logger';
 
 
 class Logger {
   private azureLogger: AzureLogger;
-  private operationId: string | undefined;
+  private operationId: string = '';
   private noOperationIdErrorMessage = 'configureOperationId must be run before using the logger';
+  hasOperationIdBeenSet: boolean = false;
 
   constructor() {
     this.azureLogger = new AzureLogger('ftts', 'ftts-location-api');
@@ -51,74 +53,62 @@ class Logger {
 
   configureOperationId(context: Context): void {
     this.operationId = getOperationId(context);
+    this.hasOperationIdBeenSet =  true;
   }
 
-  critical(message: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  critical(message: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.critical(message, this.operationId, properties);
   }
 
-  error(error: Error, message?: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  error(error: Error, message?: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.error(error, this.operationId, message, properties);
   }
 
-  warn(message: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  warn(message: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.warn(message, this.operationId, properties);
   }
 
-  info(message: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  info(message: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.info(message, this.operationId, properties);
   }
 
-  debug(message: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  debug(message: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.debug(message, this.operationId, properties);
   }
 
-  log(message: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  log(message: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.log(message, this.operationId, properties);
   }
 
-  audit(message: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  audit(message: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.audit(message, this.operationId, properties);
   }
 
-  security(message: string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
-      throw new Error(this.noOperationIdErrorMessage);
-    }
+  security(message: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
     this.azureLogger.security(message, this.operationId, properties);
   }
 
-  event(name: string, message? : string, properties?: {[key: string]: string}): void {
-    if (!this.operationId) {
+  event(name: string, message?: string, properties?: { [key: string]: string }): void {
+    this.throwIfOperationIdNotSet();
+    this.azureLogger.event(name, this.operationId, message, properties);
+  }
+
+  private throwIfOperationIdNotSet() {
+    if (!this.hasOperationIdBeenSet) {
       throw new Error(this.noOperationIdErrorMessage);
     }
-    this.azureLogger.event(name, this.operationId, message, properties);
   }
 }
 
 export default new Logger();
-
 ```
 
 2.  At the start of the azure function call configureOperationId and pass the function context in

--- a/README.md
+++ b/README.md
@@ -36,7 +36,6 @@ APPINSIGHTS_INSTRUMENTATIONKEY={APP_INSIGHTS_KEY}
 
 1) Create a class Logger called logger.ts. In this class we will create an instance of the Azure Logger, work out the operation id, and provide a wrapper for all the logger functions so we don't need to worry about the operation id elsewhere in the code.
 ```typescript
-// eslint-disable-next-line import/no-unresolved
 import { Context } from '@azure/functions';
 import { Logger as AzureLogger, getOperationId } from '@dvsa/azure-logger';
 
@@ -45,7 +44,7 @@ class Logger {
   private azureLogger: AzureLogger;
   private operationId: string = '';
   private noOperationIdErrorMessage = 'configureOperationId must be run before using the logger';
-  hasOperationIdBeenSet: boolean = false;
+  private hasOperationIdBeenSet: boolean = false;
 
   constructor() {
     this.azureLogger = new AzureLogger('ftts', 'ftts-location-api');
@@ -53,7 +52,7 @@ class Logger {
 
   configureOperationId(context: Context): void {
     this.operationId = getOperationId(context);
-    this.hasOperationIdBeenSet =  true;
+    this.hasOperationIdBeenSet = true;
   }
 
   critical(message: string, properties?: { [key: string]: string }): void {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "1.1.7",
+  "version": "1.2.0",
   "description": "Shareable Logging Facade, implemented with Winston",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/ILogger.ts
+++ b/src/ILogger.ts
@@ -1,11 +1,11 @@
 export default interface ILogger {
-  critical(message: string, properties?: {[key: string]: string}): void;
-  error(error: Error, message?: string, properties?: {[key: string]: string}): void;
-  warn(message: string, properties?: {[key: string]: string}): void;
-  info(message: string, properties?: {[key: string]: string}): void;
-  debug(message: string, properties?: {[key: string]: string}): void;
-  log(message: string, properties?: {[key: string]: string}): void;
-  audit(message: string, properties?: {[key: string]: string}): void;
-  security(message: string, properties?: {[key: string]: string}): void;
-  event(name: string, message? : string, properties?: {[key: string]: string}): void;
+  critical(message: string, operationId: string, properties?: {[key: string]: string}): void;
+  error(error: Error, operationId: string, message?: string, properties?: {[key: string]: string}): void;
+  warn(message: string, operationId: string, properties?: {[key: string]: string}): void;
+  info(message: string, operationId: string, properties?: {[key: string]: string}): void;
+  debug(message: string, operationId: string, properties?: {[key: string]: string}): void;
+  log(message: string, operationId: string, properties?: {[key: string]: string}): void;
+  audit(message: string, operationId: string, properties?: {[key: string]: string}): void;
+  security(message: string, operationId: string, properties?: {[key: string]: string}): void;
+  event(name: string, operationId: string, message? : string, properties?: {[key: string]: string}): void;
 }

--- a/src/helpers/getOperationId.ts
+++ b/src/helpers/getOperationId.ts
@@ -1,0 +1,12 @@
+// eslint-disable-next-line import/no-unresolved
+import { Context } from '@azure/functions';
+import Traceparent from 'applicationinsights/out/Library/Traceparent';
+
+function getOperationId(context: Context): string {
+  if (!context.traceContext || !context.traceContext.traceparent) {
+    return '';
+  }
+  return new Traceparent(context.traceContext.traceparent).traceId;
+}
+
+export default getOperationId;

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,4 +1,5 @@
 import Logger from './logger';
 import ILogger from './ILogger';
+import getOperationId from './helpers/getOperationId';
 
-export { Logger, ILogger };
+export { Logger, ILogger, getOperationId };

--- a/src/interfaces/index.ts
+++ b/src/interfaces/index.ts
@@ -5,7 +5,6 @@ import { LOG_LEVELS } from '../enums';
 export interface ApplicationInsightsTransportOptions extends Transport.TransportStreamOptions {
   key: string;
   componentName: string;
-  operationId: string;
 }
 
 export type LogInfo = ExceptionInfo | EventInfo | TraceInfo;
@@ -16,6 +15,7 @@ export interface ExceptionInfo {
   message: string;
   projectName: string;
   componentName: string;
+  operationId: string;
   meta: any;
   [key: string]: any;
 }
@@ -26,6 +26,7 @@ export interface EventInfo {
   projectName: string;
   componentName: string;
   message: string;
+  operationId: string;
   meta: any;
   [key: string]: any;
 }
@@ -35,6 +36,7 @@ export interface TraceInfo {
   message: string;
   projectName: string;
   componentName: string;
+  operationId: string;
   meta: any;
   [key: string]: any;
 }

--- a/tests/unit/applicationInsightsTransport.test.ts
+++ b/tests/unit/applicationInsightsTransport.test.ts
@@ -27,13 +27,11 @@ jest.mock('applicationinsights', () => ({
     context: {
       keys: {
         cloudRole: 'cloudRole',
-        operationId: 'operationId',
-        operationParentId: 'operationParentId',
+        operationId: 'ai.operation.id',
       },
       tags: {
         cloudRole: '',
         operationId: '',
-        operationParentId: '',
       },
     },
     trackTrace: jest.fn(),
@@ -52,10 +50,9 @@ describe('ApplicationInsightsTransport', () => {
       // Arrange
       const key = 'dummy-key';
       const componentName = 'azure-logger';
-      const operationId = 'operation-id';
       // Act
       const result = new ApplicationInsightsTransport({
-        key, componentName, operationId,
+        key, componentName,
       });
 
       // Assert
@@ -78,7 +75,6 @@ describe('ApplicationInsightsTransport', () => {
       applicationinsightsTransport = new ApplicationInsightsTransport({
         key,
         componentName,
-        operationId,
       });
     });
 
@@ -88,6 +84,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message,
+        operationId,
         level: LOG_LEVELS.AUDIT,
         meta: {},
         optionalProp: 'optional',
@@ -117,6 +114,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message,
+        operationId,
         level: LOG_LEVELS.CRITICAL,
         meta: [],
         optionalProp: 'optional',
@@ -146,6 +144,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message,
+        operationId,
         level: LOG_LEVELS.DEBUG,
         meta: {},
         optionalProp: 'optional',
@@ -177,6 +176,7 @@ describe('ApplicationInsightsTransport', () => {
         message,
         projectName,
         componentName,
+        operationId,
         level: LOG_LEVELS.ERROR,
         meta: {},
         optionalProp: 'optional',
@@ -208,6 +208,7 @@ describe('ApplicationInsightsTransport', () => {
         message: '',
         projectName,
         componentName,
+        operationId,
         level: LOG_LEVELS.ERROR,
         meta: {},
         optionalProp: 'optional',
@@ -236,6 +237,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message,
+        operationId,
         level: LOG_LEVELS.EVENT,
         name: eventName,
         meta: [],
@@ -265,6 +267,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message: '',
+        operationId,
         level: LOG_LEVELS.EVENT,
         name: eventName,
         meta: {},
@@ -291,6 +294,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message,
+        operationId,
         level: LOG_LEVELS.INFO,
         meta: {},
         optionalProp: 'optional',
@@ -320,6 +324,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message,
+        operationId,
         level: LOG_LEVELS.SECURITY,
         meta: {},
         optionalProp: 'optional',
@@ -349,6 +354,7 @@ describe('ApplicationInsightsTransport', () => {
         projectName,
         componentName,
         message,
+        operationId,
         level: LOG_LEVELS.WARNING,
         meta: {},
         optionalProp: 'optional',

--- a/tests/unit/helpers/getOperationId.test.ts
+++ b/tests/unit/helpers/getOperationId.test.ts
@@ -1,0 +1,23 @@
+// eslint-disable-next-line import/no-unresolved
+import { Context } from '@azure/functions';
+
+import getOperationId from '../../../src/helpers/getOperationId';
+
+describe('getOperationId', () => {
+  test('should return an empty string if there is no traceContext', () => {
+    expect(getOperationId({} as Context)).toEqual('');
+  });
+
+  test('should return an empty string if ther is no traceParent', () => {
+    expect(getOperationId({ traceContext: {} } as Context)).toEqual('');
+  });
+
+  test('should return a trace id if a traceParent exists', () => {
+    expect(getOperationId({
+      traceContext:
+      {
+        traceparent: '00-763230142f4317478bf6bdcee3886ef0-2839ff750bf4cc46-00',
+      },
+    } as Context)).toEqual('763230142f4317478bf6bdcee3886ef0');
+  });
+});

--- a/tests/unit/logger.test.ts
+++ b/tests/unit/logger.test.ts
@@ -24,16 +24,9 @@ describe('Logger', () => {
     log: jest.fn(),
     warn: jest.fn(),
   };
-  const mockContext: any = {
-    traceContext: {
-      traceparent: 'trace-parent',
-      tracestate: 'trace-state',
-      attributes: {},
-    },
-  };
   const logMessage = 'test log message';
-  const logProps = { componentName: 'azure-logger', projectName: 'DVSA' };
-  const notSetupErrorMessage = 'Logger is not configured, please run Logger.setup() first';
+  const logProps = { componentName: 'azure-logger', projectName: 'DVSA', operationId: 'operation-id' };
+  const operationId = 'operation-id';
 
   beforeAll(() => {
     mockCreateLogger = jest.spyOn(winston, 'createLogger');
@@ -52,26 +45,21 @@ describe('Logger', () => {
     jest.restoreAllMocks();
   });
 
-  describe('setup', () => {
+  describe('constructor', () => {
     test('should correctly configure application insights', () => {
-      // act
-      loggerInstance.setup(mockContext);
       // assert
       expect(ApplicationInsightsTransport).toHaveBeenCalledWith({
         level: 'DEBUG',
         key: '123-456-789',
         componentName: 'azure-logger',
-        operationId: 'parent',
       });
     });
   });
 
   describe('critical', () => {
     test('should create a critical log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.critical(logMessage);
+      loggerInstance.critical(logMessage, operationId);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.CRITICAL,
@@ -81,33 +69,21 @@ describe('Logger', () => {
     });
 
     test('should create a critical log with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.critical(logMessage, { isTest: 'true' });
+      loggerInstance.critical(logMessage, operationId, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.CRITICAL,
         logMessage,
-        {...logProps, isTest: 'true'},
+        { ...logProps, isTest: 'true'},
       );
-    });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.critical(logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
     });
   });
 
   describe('debug', () => {
     test('should create a debug log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.debug(logMessage);
+      loggerInstance.debug(logMessage, operationId);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.DEBUG,
@@ -117,10 +93,8 @@ describe('Logger', () => {
     });
 
     test('should create a debug log with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.debug(logMessage, { isTest: 'true' });
+      loggerInstance.debug(logMessage, operationId, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.DEBUG,
@@ -128,22 +102,12 @@ describe('Logger', () => {
         { ...logProps, isTest: 'true' },
       );
     });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.debug(logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
-    });
   });
 
   describe('audit', () => {
     test('should create a audit log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.audit(logMessage);
+      loggerInstance.audit(logMessage, operationId);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.AUDIT,
@@ -153,10 +117,8 @@ describe('Logger', () => {
     });
 
     test('should create a audit log with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.audit(logMessage, { isTest: 'true' });
+      loggerInstance.audit(logMessage, operationId, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.AUDIT,
@@ -164,22 +126,12 @@ describe('Logger', () => {
         { ...logProps, isTest: 'true' },
       );
     });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.audit(logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
-    });
   });
 
   describe('security', () => {
     test('should create a security log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.security(logMessage);
+      loggerInstance.security(logMessage, operationId);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.SECURITY,
@@ -189,10 +141,8 @@ describe('Logger', () => {
     });
 
     test('should create a security log with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.security(logMessage, { isTest: 'true' });
+      loggerInstance.security(logMessage, operationId, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.SECURITY,
@@ -200,25 +150,14 @@ describe('Logger', () => {
         { ...logProps, isTest: 'true' },
       );
     });
-
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.security(logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
-    });
   });
 
   describe('error', () => {
     const mockError = new Error('Mock Error');
 
     test('should create a error log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.error(mockError);
+      loggerInstance.error(mockError, operationId);
       // assert
       expect(mockLogger.error).toHaveBeenCalledWith(
         '',
@@ -227,10 +166,8 @@ describe('Logger', () => {
     });
 
     test('should create a error log with an optional error message', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.error(mockError, logMessage);
+      loggerInstance.error(mockError, operationId, logMessage);
       // assert
       expect(mockLogger.error).toHaveBeenCalledWith(
         logMessage,
@@ -239,10 +176,8 @@ describe('Logger', () => {
     });
 
     test('should create a error log with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.error(mockError, undefined, { isTest: 'true' });
+      loggerInstance.error(mockError, operationId, undefined, { isTest: 'true' });
       // assert
       expect(mockLogger.error).toHaveBeenCalledWith(
         '',
@@ -251,32 +186,20 @@ describe('Logger', () => {
     });
 
     test('should create a error log with an optional message and properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.error(mockError, logMessage, { isTest: 'true' });
+      loggerInstance.error(mockError, operationId, logMessage, { isTest: 'true' });
       // assert
       expect(mockLogger.error).toHaveBeenCalledWith(
         logMessage,
         { ...logProps, error: mockError, isTest: 'true' },
       );
     });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.error(mockError, logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
-    });
   });
 
   describe('info', () => {
     test('should create a info log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.info(logMessage);
+      loggerInstance.info(logMessage, operationId);
       // assert
       expect(mockLogger.info).toHaveBeenCalledWith(
         logMessage,
@@ -285,32 +208,20 @@ describe('Logger', () => {
     });
 
     test('should create a info log with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.info(logMessage, { isTest: 'true' });
+      loggerInstance.info(logMessage, operationId, { isTest: 'true' });
       // assert
       expect(mockLogger.info).toHaveBeenCalledWith(
         logMessage,
         { ...logProps, isTest: 'true' },
       );
     });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.info(logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
-    });
   });
 
   describe('log', () => {
     test('should create a log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.log(logMessage);
+      loggerInstance.log(logMessage, operationId);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.INFO,
@@ -320,10 +231,8 @@ describe('Logger', () => {
     });
 
     test('should create a log with additional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.log(logMessage, { isTest: 'true' });
+      loggerInstance.log(logMessage, operationId, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.INFO,
@@ -331,22 +240,12 @@ describe('Logger', () => {
         { ...logProps, isTest: 'true' },
       );
     });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.log(logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
-    });
   });
 
   describe('warn', () => {
     test('should create a warn log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.warn(logMessage);
+      loggerInstance.warn(logMessage, operationId);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.WARNING,
@@ -356,24 +255,14 @@ describe('Logger', () => {
     });
 
     test('should create a warn log with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.warn(logMessage, { isTest: 'true' });
+      loggerInstance.warn(logMessage, operationId, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.WARNING,
         logMessage,
         { ...logProps, isTest: 'true' },
       );
-    });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.warn(logMessage);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
     });
   });
 
@@ -382,10 +271,8 @@ describe('Logger', () => {
     const mockEventMessage = 'mock-event-message';
 
     test('should create a event log', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.event(mockEventName);
+      loggerInstance.event(mockEventName, operationId);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.EVENT,
@@ -395,10 +282,8 @@ describe('Logger', () => {
     });
 
     test('should create a event with an optional message', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.event(mockEventName, mockEventMessage);
+      loggerInstance.event(mockEventName, operationId, mockEventMessage);
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.EVENT,
@@ -408,10 +293,8 @@ describe('Logger', () => {
     });
 
     test('should create a event with optional properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.event(mockEventName, undefined, { isTest: 'true' });
+      loggerInstance.event(mockEventName, operationId, undefined, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.EVENT,
@@ -421,24 +304,14 @@ describe('Logger', () => {
     });
 
     test('should create a event with an optional message and properties', () => {
-      // arrange
-      loggerInstance.setup(mockContext);
       // act
-      loggerInstance.event(mockEventName, mockEventMessage, { isTest: 'true' });
+      loggerInstance.event(mockEventName, operationId, mockEventMessage, { isTest: 'true' });
       // assert
       expect(mockLogger.log).toHaveBeenCalledWith(
         LOG_LEVELS.EVENT,
         mockEventMessage,
         { ...logProps, name: mockEventName, isTest: 'true' },
       );
-    });
-
-    test('should throw an error if setup has not been run', () => {
-      try {
-        loggerInstance.event(mockEventName);
-      } catch (error) {
-        expect(error.message).toEqual(notSetupErrorMessage);
-      }
     });
   });
 });


### PR DESCRIPTION
This should be the final version of the azure-logger for FTT-2602

1) The interface ILogger has been updated so that all log functions need to pass in an operation id, which is then manually set when we talk to application insights. Team G were having issues with the operation id being overwritten inside the logger in previous versions so, the function implementing the logger is now responsible for managing it and making sure it's correct.

2) The setup function has been removed the code simplified due to it.

3) The package now exports a helper function to work out the operation id from the azure function context.

4) Updated the readme with a new example on how to use the logger- https://github.com/dvsa/azure-logger/tree/feature/ftt-2602-final-version-tidy-up


