### PR TITLE
FTT-3568 - Generate operation id if missing

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@dvsa/azure-logger",
-  "version": "2.0.0",
+  "version": "2.0.1",
   "description": "Shareable Logging Facade, implemented with Winston",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",

--- a/src/helpers/getOperationId.ts
+++ b/src/helpers/getOperationId.ts
@@ -4,7 +4,7 @@ import Traceparent from 'applicationinsights/out/Library/Traceparent';
 
 function getOperationId(context: Context): string {
   if (!context.traceContext || !context.traceContext.traceparent) {
-    return '';
+    return new Traceparent('').traceId;
   }
   return new Traceparent(context.traceContext.traceparent).traceId;
 }

--- a/src/helpers/getOperationId.ts
+++ b/src/helpers/getOperationId.ts
@@ -4,7 +4,7 @@ import Traceparent from 'applicationinsights/out/Library/Traceparent';
 
 function getOperationId(context: Context): string {
   if (!context.traceContext || !context.traceContext.traceparent) {
-    return new Traceparent('').traceId;
+    return new Traceparent(undefined).traceId;
   }
   return new Traceparent(context.traceContext.traceparent).traceId;
 }

--- a/tests/unit/helpers/getOperationId.test.ts
+++ b/tests/unit/helpers/getOperationId.test.ts
@@ -10,11 +10,11 @@ import getOperationId from '../../../src/helpers/getOperationId';
 Util.w3cTraceId = jest.fn().mockReturnValue('new-trace-id');
 
 describe('getOperationId', () => {
-  test('should return an new operation id if there is no traceContext', () => {
+  test('should return a new operation id if there is no traceContext', () => {
     expect(getOperationId({} as Context)).toEqual('new-trace-id');
   });
 
-  test('should return an empty string if ther is no traceParent', () => {
+  test('should return a new operation id if there is no traceParent', () => {
     expect(getOperationId({ traceContext: {} } as Context)).toEqual('new-trace-id');
   });
 

--- a/tests/unit/helpers/getOperationId.test.ts
+++ b/tests/unit/helpers/getOperationId.test.ts
@@ -1,15 +1,21 @@
 // eslint-disable-next-line import/no-unresolved
 import { Context } from '@azure/functions';
-
+import Util from 'applicationinsights/out/Library/Util';
 import getOperationId from '../../../src/helpers/getOperationId';
 
+/*
+  If there isn't a traceparent passed into Traceparent, the function Util.w3cTraceId
+  is used to generate a new operation id
+*/
+Util.w3cTraceId = jest.fn().mockReturnValue('new-trace-id');
+
 describe('getOperationId', () => {
-  test('should return an empty string if there is no traceContext', () => {
-    expect(getOperationId({} as Context)).toEqual('');
+  test('should return an new operation id if there is no traceContext', () => {
+    expect(getOperationId({} as Context)).toEqual('new-trace-id');
   });
 
   test('should return an empty string if ther is no traceParent', () => {
-    expect(getOperationId({ traceContext: {} } as Context)).toEqual('');
+    expect(getOperationId({ traceContext: {} } as Context)).toEqual('new-trace-id');
   });
 
   test('should return a trace id if a traceParent exists', () => {


### PR DESCRIPTION
Previously if the traceContext or traceParent was missing we would return an empty string. We now return a new operation id instead.